### PR TITLE
Allow null input for timeout

### DIFF
--- a/Command/SyncProjectCommand.php
+++ b/Command/SyncProjectCommand.php
@@ -42,6 +42,10 @@ class SyncProjectCommand extends ContainerAwareCommand
 
         $start = microtime(true);
 
+        if (!$timeout) {
+            $timeout = 60;
+        }
+
         try {
             $this->prepareSync($config, $io);
             $this->syncFilesystem($config, $io, $timeout);


### PR DESCRIPTION
If no input argument for the timeout is given, the timeout is set to the default of 60 seconds.